### PR TITLE
update DataFrame notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ using RDatasets
 using Gadfly
 
 cars = dataset("datasets","cars")
-X = map(Float64,convert(Array,cars[:Speed]))
-Y = map(Float64,convert(Array,cars[:Dist]))
+X = map(Float64,convert(Array,cars[!,:Speed]))
+Y = map(Float64,convert(Array,cars[!,:Dist]))
 
 spl = fit(SmoothingSpline, X, Y, 250.0) # λ=250.0
 Ypred = predict(spl) # fitted vector


### PR DESCRIPTION
the example does not run as it is because of an outdated notation of DataFrames to select columns